### PR TITLE
Refactor the entire project

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # actuonix-lac
 Python module for controlling an Actuonix Linear Actuator Control Board (https://www.actuonix.com/LAC-Board-p/lac.htm).
 
-There's *probably* other APIs out there for the same device, and they're *probaby* better than this one, and they're *probably* written in C, but we made one anyways. Too bad we had to use Python instead of HolyC, but meh; it's fine
+Other APIs exist for these, but we made one anyways, and if I'm not mistaken it was good enough to be used in a
+telescope owned by the University of Rochester in New York. Since then I've cleaned up the project a lot.

--- a/actuonix_lac/lac.py
+++ b/actuonix_lac/lac.py
@@ -1,170 +1,283 @@
-import struct
 import usb.core
-import time
+from typing import Tuple
+from struct import pack
+from time import sleep
 
 class LAC:
-    SET_ACCURACY                = 0x01
-    SET_RETRACT_LIMIT           = 0x02
-    SET_EXTEND_LIMIT            = 0x03
-    SET_MOVEMENT_THRESHOLD      = 0x04
-    SET_STALL_TIME              = 0x05
-    SET_PWM_THRESHOLD           = 0x06
-    SET_DERIVATIVE_THRESHOLD    = 0x07
-    SET_MAX_DERIVATIVE          = 0x08
-    SET_MIN_DERIVATIVE          = 0x09
-    SET_MAX_PWM_VALUE           = 0x0A
-    SET_MIN_PWM_VALUE           = 0x0B
-    SET_Kp                      = 0x0C
-    SET_Kd                      = 0x0D
-    SET_AVERAGE_RC              = 0x0E
-    SET_AVERAGE_ADC             = 0x0F
 
-    GET_FEEDBACK                = 0x10
+	# All of these constants are used to command the LAC; all were copied directly from the configuration datasheet
 
-    SET_POSITION                = 0x20
-    SET_SPEED                   = 0x21
+	SET_ACCURACY                = 0x01
+	SET_RETRACT_LIMIT           = 0x02
+	SET_EXTEND_LIMIT            = 0x03
+	SET_MOVEMENT_THRESHOLD      = 0x04
+	SET_STALL_TIME              = 0x05
+	SET_PWM_THRESHOLD           = 0x06
+	SET_DERIVATIVE_THRESHOLD    = 0x07
+	SET_MAX_DERIVATIVE          = 0x08
+	SET_MIN_DERIVATIVE          = 0x09
+	SET_MAX_PWM_VALUE           = 0x0A
+	SET_MIN_PWM_VALUE           = 0x0B
+	SET_Kp                      = 0x0C
+	SET_Kd                      = 0x0D
+	SET_AVERAGE_RC              = 0x0E
+	SET_AVERAGE_ADC             = 0x0F
 
-    DISABLE_MANUAL              = 0x30
+	GET_FEEDBACK                = 0x10
 
-    RESET                       = 0xFF
+	SET_POSITION                = 0x20
+	SET_SPEED                   = 0x21
 
-    def __init__(self, vendorID=0x4D8, productID=0xFC5F):
-        self.device = usb.core.find(idVendor=vendorID, idProduct=productID)  # Defaults for our LAC; give yours a test
-        if self.device is None:
-            raise Exception("No board found, ensure board is connected and powered and matching the IDs provided")
+	DISABLE_MANUAL              = 0x30
 
-        self.device.set_configuration()
+	RESET                       = 0xFF
 
-    # Take data and send it to LAC
-    def send_data(self, function, value=0):
-        if value < 0 or value > 1023:
-            raise ValueError("Value is OOB. Must be 2-byte integer in rage [0, 1023]")
+	def __init__(self, stroke: float, vendorID: int = 0x4D8, productID: int = 0xFC5F):
+		"""
+		LAC class initializer. stroke is the maximum length of your specific actuator in millimeters, for example 30
+		would be used as the stroke for a 30mm LAC.
 
-        data = struct.pack(b'BBB', function, value & 0xFF, (value & 0xFF00) >> 8)  # Low byte masked in, high byte masked and moved down
-        self.device.write(1, data, 100)  # Magic numbers from the PyUSB tutorial
-        time.sleep(.05)  # Just to be sure it's all well and sent
-        response = self.device.read(0x81, 3, 100)  # 3 because there's three bytes to a packet
-        return (response[2] << 8) + response[1]  # High byte moved left, then tack on the low byte
+		The default vendorID and productID came from our own actuator; be sure to test for your own values! Good
+		operating systems have the `lsusb` command, which contains an ID field in the form VID:PID.
 
-    # How close to target distance is accepted
-    # value/1024 * stroke gives distance, where stroke is max
-    # extension length (all values in mm). Round to nearest
-    # integer
-    def set_accuracy(self, value=4):
-        self.send_data(self.SET_ACCURACY, value)
+		Winblows users can (allegedly) go to "Device manager", find the LAC, right click, choose "Properties", then
+		"Details", then "Hardware IDs", and find an entry in the form `HID\VID_XXXX&PID_YYYY` which correspond to the
+		vendor (XXXX) and product (YYYY) IDs. That's according to this:
+		https://superuser.com/a/1106248
+		"""
+		if stroke < 0 or vendorID < 0 or productID < 0:
+			raise ValueError("No parameters can be negative values")
 
-    # How far back the actuator can go. A value
-    # of 0 hits the mechanical stop, but this
-    # is not recommended. The value you want to send
-    # is calculated by (distance * 1023)/stroke where
-    # distance is intended distance and stroke is max
-    # extension length, all values in mm. Round to
-    # nearest integer
-    def set_retract_limit(self, value):
-        self.send_data(self.SET_RETRACT_LIMIT, value)
+		self.device = usb.core.find(idVendor = vendorID, idProduct = productID)
+		if self.device is None:
+			raise Exception("No board found, ensure board is connected and powered with matching ID")
 
-    # How far forward the actuator can go. A value
-    # of 1023 hits the mechanical stop, but this
-    # is not recommended. See above for math
-    def set_extend_limit(self, value):
-        self.send_data(self.SET_EXTEND_LIMIT, value)
+		self.device.set_configuration()
+		self.stroke = stroke
 
-    # Minimum speed before actuator is considered stalling
-    def set_movement_threshold(self, value):
-        self.send_data(self.SET_MOVEMENT_THRESHOLD, value)
+	def send_data(self, function: int, value: int = 0) -> Tuple[int, int]:
+		"""
+		Send data to the LAC. The return value is an echo of the sent packet, unless otherwise stated.
 
-    # Timeout (ms) before actuator shuts off after stalling
-    def set_stall_time(self, value):
-        self.send_data(self.SET_STALL_TIME, value)
+		The first item in the response is (probably?) the current control mode (like `function`). The second item is the
+		two-byte data as an integer (like `value`). On account of endianness, the bytes are manually swapped
+		"""
+		if not 0 <= value <= 1023:
+			raise ValueError("Value is out of bounds. Must be 2-byte integer in range [0, 1023]")
 
-    # When feedback-set>this, set speed to maximum
-    def set_pwm_threshold(self, value):
-        self.send_data(self.SET_PWM_THRESHOLD, value)
+		# Bytes are separated: low byte first, then high byte. Former is masked, latter is shifted into position
+		data = pack(b"BBB", function, value & 0xFF, value >> 8)
 
-    # Compared to measured speed to determine
-    # PWM increase (prevents stalls). Normally
-    # equal to movement threshold
-    def set_derivative_threshold(self, value):
-        self.send_data(self.SET_DERIVATIVE_THRESHOLD, value)
+		# These magic numbers were gleefully stolen from the PyUSB tutorial
+		# TODO: is there a better way to ensure data is fully sent than sleeping for 50ms?
+		self.device.write(1, data, 100)
+		sleep(.05)
 
-    # Maximum value the D term can contribute to control speed
-    def set_max_derivative(self, value):
-        self.send_data(self.SET_MAX_DERIVATIVE, value)
+		# Three bytes per packet
+		# I assume the 0x81 and 100 here also came from the PyUSB tutorial, but I never actually wrote that down...
+		response = self.device.read(0x81, 3, 100)
 
-    # Minimum value the D term can contribute to control speed
-    def set_min_derivative(self, value):
-        self.send_data(self.SET_MIN_DERIVATIVE, value)
+		# Just as before, the bytes are separated, so here they're put back together as one integer
+		return response[0], (response[2] << 8) + response[1]
 
-    # Speed the actuator runs at when outside the pwm threshold
-    # 1023 enables top speed, though actuator may try to move
-    # faster to avoid stalling
-    def set_max_pwm_value(self, value):
-        self.send_data(self.SET_MAX_PWM_VALUE, value)
+	def set_accuracy(self, accuracy: float = .117) -> Tuple[int, int]:
+		"""
+		Describes how close the LAC needs to get to its target position before stopping, in millimeters. The default
+		value gives the arm ±0.117mm of lenience to its requested destination. According to the datasheet, with too low
+		a value, the arm could move back and forth around the desired position endlessly.
 
-    # Minimum PWM value applied by PD
-    def set_min_pwm_value(self, value):
-        self.send_data(self.SET_MIN_PWM_VALUE, value)
+		Because of the natures of floats and the LAC's integer-based interface, there is ironically some inaccuracy
+		between the parameter and the result
+		"""
+		return self.send_data(self.SET_ACCURACY, int(round(accuracy/self.stroke * 1024)))
 
-    # Higher value = faster approach to target, but also more
-    # overshoot
-    def set_proportional_gain(self, value):
-        self.send_data(self.SET_PROPORTIONAL_GAIN, value)
+	def set_retract_limit(self, length: float) -> Tuple[int, int]:
+		"""
+		Retract limit gives the actuator a minimum length, in millimeters.
 
-    # Rate at which differential portion of controller increases
-    # while stalling. Not a /real/ differential term, but
-    # similar effect. When stalling, derivtive term is
-    # incremented to attempt escape
-    def set_derivative_gain(self, value):
-        self.send_data(self.SET_DERIVATIVE_GAIN, value)
+		A value of zero would contact the mechanical stop, but according to the datasheet, "it is recommended to offset
+		[this value] to ensure the actuator is never driven into the physical end stops. This increases cycle life
+		considerably." In English, don't do that
+		"""
+		return self.send_data(self.SET_RETRACT_LIMIT, int(round(length/self.stroke * 1023)))
 
-    # Number of samples used in filtering the RC input signal
-    # before the actuator moves. High value = more stability,
-    # but lower response time. value * 20ms = delay time.
-    # This does NOT affect filter feedback delay; control
-    # response to valid input signals is unaffected
-    def set_average_rc(self, value=4):
-        self.send_data(self.SET_AVERAGE_RC, value)
+	def set_extend_limit(self, length: float) -> Tuple[int, int]:
+		"""
+		Extend limit gives the actuator a maximum length, in millimeters.
 
-    # Number of samples used in filtering the feedback and analog
-    # input signals, if active. Similar delay effect to
-    # set_average_rc, but this DOES affect control response. PD
-    # loop values may need to be retuned when adjusting this
-    def set_average_adc(self, value):
-        self.send_data(self.SET_AVERAGE_ADC, value)
+		A value equal to `stroke` from the constructor would contact the mechanical stop, but according to the
+		datasheet, "it is recommended to offset [this value] to ensure the actuator is never driven to the physical end
+		stops. This increases cycle life considerably." In English, don't do that
+		"""
+		return self.send_data(self.SET_EXTEND_LIMIT, int(round(length/self.stroke * 1023)))
 
+	def set_movement_threshold(self, value: int) -> Tuple[int, int]:
+		"""
+		The datasheet describes this value as "the minimum actuator speed that is considered a stall", and warns that
+		"the stall timer begins counting" when the movement speed of the actuator falls below the given value. See also
+		`set_stall_time`.
 
-    # Causes actuator to send a feedback packet containing its
-    # current position. This is read directly from ADC and might
-    # not be equal to the set point if yet unreached
-    def get_feedback(self):
-        return self.send_data(self.GET_FEEDBACK)
+		No units, equations, range, or other helpful info are provided
+		"""
+		return self.send_data(self.SET_MOVEMENT_THRESHOLD, value)
 
+	def set_stall_time(self, time: int) -> Tuple[int, int]:
+		"""
+		The amount of time, in milliseconds, the actuator will wait before stopping the motor after a stall is detected
+		(see also `set_movement_threshold`). According to the datasheet, "the actuator will exit this state when the
+		input signal tells the actuator to move in the opposite direction". If the stall is resolved in time, the stall
+		timer will reset.
 
-    # Set the LAC's position. This shouldn't be shocking, given
-    # like ya know the name of the function? Note that this will
-    # disable RC, I, and V inputs until reboot. To know what
-    # number to send, do (distance * 1023)/stroke where distance
-    # is intended position as a distance from the back hardstop,
-    # in mm, and stroke is the maximum length of extension, in mm.
-    # Be sure to round your result to the nearest integer!
-    def set_position(self, value):
-        self.send_data(self.SET_POSITION, value)
+		Whether "this state" refers to the pre- or post-stop stall is unclear to me.
 
-    # This command is not documented, but it's probably
-    # easy to infer and just guess via trial by fire
-    def set_speed(self, value):
-        self.send_data(self.SET_SPEED, value)
+		The value is almost certainly a 2-byte integer, but that is my extrapolation from technical details -- it's not
+		officially stated
+		"""
+		return self.send_data(self.SET_STALL_TIME, time)
 
+	def set_pwm_threshold(self, value: int) -> Tuple[int, int]:
+		"""
+		Described as setting "the distance around the set point where the PWM PD controller is active", whatever that
+		means (particularly the "set point". Perhaps that relates to `set_position`?).
 
-    # Saves current config to EEPROM and disables all four
-    # potentiometers. On reboot, these values will continue being used
-    # instead of the potentiometer values. Analog inputs function
-    # as normal either way
-    def disable_manual(self):
-        self.send_data(self.DISABLE_MANUAL)
+		If the difference between the feedback (see `get_feedback`) and set point is greater than the given value, the
+		actuator's speed is maxed.
 
+		No units, equations, range, or other helpful info are provided
+		"""
+		return self.send_data(self.SET_PWM_THRESHOLD, value)
 
-    # Enables manual control potentiometers and resets config
-    # to factory default
-    def reset(self):
-        self.send_data(self.RESET)
+	def set_derivative_threshold(self, value: int) -> Tuple[int, int]:
+		"""
+		The derivative threshold is used to determine when PWM should be increased to exit a stall, based on the current
+		speed. The datasheet claims it's normally set equal to the movement threshold (see `set_movement_threshold`).
+
+		No units, equations, range, or other helpful info are provided
+		"""
+		return self.send_data(self.SET_DERIVATIVE_THRESHOLD, value)
+
+	def set_max_derivative(self, value: int) -> Tuple[int, int]:
+		"""
+		Maximum value that the derivative term contributes to controlling speed. Probably involced in PD control? See
+		also `set_min_derivative`.
+
+		No units, equations, range, or other helpful info are provided
+		"""
+		return self.send_data(self.SET_MAX_DERIVATIVE, value)
+
+	def set_min_derivative(self, value: int) -> Tuple[int, int]:
+		"""
+		Minimum value that the derivative term contributes to controlling speed. Probably involced in PD control? See
+		also `set_max_derivative`.
+
+		No units, equations, range, or other helpful info are provided
+		"""
+		return self.send_data(self.SET_MIN_DERIVATIVE, value)
+
+	def set_max_pwm_value(self, value: int) -> Tuple[int, int]:
+		"""
+		Sets the value "manually controlled by the speed potentiometer". When outside the PWM threshold (see
+		`set_pwm_threshold`), this is the actuator's speed. 1023 represents maximum speed. Regardless of the value set,
+		the actually may actually exceed it while attempting to exit a stall. Whether 1023 can be exceeded is unclear.
+
+		No units, equations, range, or other helpful info are provided
+		"""
+		return self.send_data(self.SET_MAX_PWM_VALUE, value)
+
+	def set_min_pwm_value(self, value: int) -> Tuple[int, int]:
+		"""
+		Sets the value that the datasheet simply calls "the minimum PWM value that can be applied by the PD control".
+
+		No units, equations, range, or other helpful info are provided
+		"""
+		return self.send_data(self.SET_MIN_PWM_VALUE, value)
+
+	def set_proportional_gain(self, value: int) -> Tuple[int, int]:
+		"""
+		This sets the Kp value, the proportional control term. Higher values result in a faster approach to the target
+		position, but that can also make overshoot more likely. If that happens, reducing Kp will reduce overshoot.
+
+		No units, equations, range, or other helpful info are provided
+		"""
+		return self.send_data(self.SET_PROPORTIONAL_GAIN, value)
+
+	def set_derivative_gain(self, value: int) -> Tuple[int, int]:
+		"""
+		Sets the rate at which the differential control term increases when stalling. This is not an actual differential
+		term, but it has a similar effect. If a stall is detected, the derivative term increments.
+
+		No units, equations, range, or other helpful info are provided. I presume the increment is equal to this value,
+		but that is entirely unclear from the datasheet
+		"""
+		return self.send_data(self.SET_DERIVATIVE_GAIN, value)
+
+	# TODO: does this value affect the `sleep(.05)` in the contructor?
+	def set_average_rc(self, samples: int = 4) -> Tuple[int, int]:
+		"""
+		Sets the value which determines how many samples are used when filtering the RC input before the actuator is
+		moved. Increasing this value can improve stability, but will affect response time. One sample costs 20ms of
+		delay. Feedback filter delay and control response to a valid input signal are unaffected
+		"""
+		return self.send_data(self.SET_AVERAGE_RC, samples)
+
+	def set_average_adc(self, samples: int) -> Tuple[int, int]:
+		"""
+		Sets the value which detemines the number of samples used in filtering the feedback and analog input signals, if
+		active. Increasing this value increases the feedback filter delay, where one sample costs 20ms of delay. Unlike
+		`set_average_rc`, this delay affects actuator control response. This delay allows the actuator to move before
+		using PD to update the speed, so other values may need retuning after changing this
+		"""
+		return self.send_data(self.SET_AVERAGE_ADC, samples)
+
+	def get_feedback(self) -> int:
+		"""
+		Per the datasheet, "This command causes the actuator to respond with a feedback packet containing the current
+		actuator position. This is read directly from the ADC and may not be equal to the set point if the actuator has
+		not yet reached it."
+
+		Because the control mode seems irrelevant, it is left out of this function's return value. How the return value
+		relates to the millimeter length of the arm isn't described, but I suspect it's the inverse equation of the
+		`set_position` function
+		"""
+		return self.send_data(self.GET_FEEDBACK)[1]
+
+	def set_position(self, distance: int) -> Tuple[int, int]:
+		"""
+		Tells the actuator what distance to extend to, in millimeters from the base.
+
+		Using this command disables RC, I, and V inputs until reboot, but enables USB control.
+
+		This is the only command with a response that isn't a simple echo. Instead, the second value of the tuple
+		represents the arm's current position
+		"""
+		return self.send_data(self.SET_POSITION, int(round(distance/self.stroke * 1023)))
+
+	def set_speed(self, value: int) -> Tuple[int, int]:
+		"""
+		This command is not documented in the datasheet at all.
+
+		There are four potentiometers on the board, and only one does not have a matching documented USB control
+		function. For that reason, I suspect this function mirrors the speed potentiometer in the same way that the
+		`set_accuracy` function mirrors the accuracy potentiometer
+		"""
+		return self.send_data(self.SET_SPEED, value)
+
+	def disable_manual(self, value: int = 0):
+		"""
+		Save the current configration to EEPROM and disable all four potentiometers.
+
+		On reboot, these values will be used instead of the potentiometer values. Analog inputs are not affected. What
+		"these values" refers to is unclear, though I suspect it is the accuracy, retract limit, extend limit, and speed
+		functions' values.
+
+		Whether the `value` parameter has any effect is also unclear. For that reason, I have it defaulting to zero
+		"""
+		self.send_data(self.DISABLE_MANUAL)
+
+	def reset(self, value: int = 0):
+		"""
+		Enable the manual control potentiometers and reset the configuration settings.
+
+		I doubt the `value` parameter has any effect, so I have defaulted it to zero
+		"""
+		self.send_data(self.RESET)

--- a/actuonix_lac/lac.py
+++ b/actuonix_lac/lac.py
@@ -1,4 +1,4 @@
-import usb.core
+from usb.core import find as find_usb
 from typing import Tuple
 from struct import pack
 from time import sleep
@@ -48,7 +48,7 @@ class LAC:
 		if stroke < 0 or vendorID < 0 or productID < 0:
 			raise ValueError("No parameters can be negative values")
 
-		self.device = usb.core.find(idVendor = vendorID, idProduct = productID)
+		self.device = find_usb(idVendor = vendorID, idProduct = productID)
 		if self.device is None:
 			raise Exception("No board found, ensure board is connected and powered with matching ID")
 
@@ -247,8 +247,8 @@ class LAC:
 
 		Using this command disables RC, I, and V inputs until reboot, but enables USB control.
 
-		This is the only command with a response that isn't a simple echo. Instead, the second value of the tuple
-		represents the arm's current position
+		This command's response isn't a simple echo. Instead, the second value of the tuple represents the arm's current
+		position
 		"""
 		return self.send_data(self.SET_POSITION, int(round(distance/self.stroke * 1023)))
 


### PR DESCRIPTION
The refactor clarifies some function details, uses docstrings instead of comment blocks, and simplifies functions with documented intention-value converstion equations (such as `set_position`). The appropriate version bump was already pushed to master.

It has not been tested because I cannot test it because I do not own the required hardware. I would buy it, but I don't have any use for it besides about 20 minutes of testing this single commit.

Several other subtle changes were made: functions and parameters have been type hinted, the high byte mask-and-shift in `send_data` has been replaced with a simple shift, the `value` range check in `send_data` was streamlined via comparison operator chaining, and the `stroke` and USB ID values have been checked for negatives.

The most important change is a proper implementation of the `stroke` value. Previously, it was just specified as part of a handful of equations the user had to calculate. Instead, it is now a required constructor parameter, and is used in these equations automatically. This prevents accidental inconsistency errors on the users' behalf and enables the aforementioned simplification of equation-based functions like `set_position`.

Additionally, the packet echo from sending data over USB has been implemented as function returns, in case any users want that echo. It proves especially useful in the case of `set_position` and `get_feedback` because those functions do not simply echo the sent packet.

Several comments as well as the readme have also been de-cringed.